### PR TITLE
Switch to calling setup as a closure action

### DIFF
--- a/addon/components/body-movin.js
+++ b/addon/components/body-movin.js
@@ -37,7 +37,9 @@ export default Ember.Component.extend({
       wrapper: document.getElementById(this.get('elementId'))
     });
 
-    this.sendAction('setup', animation);
+    if (this.setup) {
+      this.setup(animation);
+    }
     this.set('animation', animation);
   },
 


### PR DESCRIPTION
`sendAction` has been deprecated in ember 3.4 and closure actions are now recommended. 

https://deprecations-app-prod.herokuapp.com/deprecations/v3.x/#toc_ember-component-send-action